### PR TITLE
renamed env var

### DIFF
--- a/endpoints.go
+++ b/endpoints.go
@@ -9,7 +9,7 @@ var endpoint string
 
 func init() {
 	// Set endpoint to whatever is in env
-	switch env := os.Getenv("BOOSTE_URL"); env {
+	switch env := os.Getenv("BANANA_URL"); env {
 	case "":
 		// Prod case, zero value
 		endpoint = "http://api.banana.dev/"


### PR DESCRIPTION
# Why
Env var for configurable endpoint was BOOSTE_URL and not BANANA_URL