### PR TITLE
working end to end with .run .start .check without API break

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+testing
+
 # Binaries for programs and plugins
 *.exe
 *.exe~

--- a/banana.go
+++ b/banana.go
@@ -10,63 +10,84 @@ import (
 
 // Run will call the inference pipeline on custom models with the use of a model key.
 // It is a syncronous wrapper around the async Start and Check functions.
-func Run(apiKey string, modelKey string, inputs []byte) (outCheckV2, error) {
+func Run(apiKey string, modelKey string, inputs []byte) (Result, error) {
 
 	// Start the task
-	callID, err := Start(apiKey, modelKey, inputs)
+	startOnly := false
+	res, err := subStart(apiKey, modelKey, inputs, startOnly)
 	if err != nil {
-		return outCheckV2{}, err
+		return Result{}, err
 	}
 
-	re := outCheckV2{}
+	// catch the case where the start endpoint actually returned results
+	if res.Finished {
+		out := Result{
+			ID:           res.ID,
+			Message:      res.Message,
+			Created:      res.Created,
+			APIVersion:   res.APIVersion,
+			ModelOutputs: res.ModelOutputs,
+		}
+		return out, nil
+	}
 
-	// Poll check until done
+	// Else if long running, poll check until done
+	out := Result{}
 	for {
-		re, err = Check(apiKey, callID)
+		out, err = Check(apiKey, res.CallID)
 		if err != nil {
-			return outCheckV2{}, err
+			return Result{}, err
 		}
 
-		if strings.ToLower(re.Message) == "success" {
+		if strings.ToLower(out.Message) == "success" {
 			break
 		}
 	}
 
-	return re, nil
+	return out, nil
 }
 
 // Start will start an async inference task and return a task ID.
 func Start(apiKey string, modelKey string, inputs []byte) (callID string, err error) {
+	startOnly := true
+	re, err := subStart(apiKey, modelKey, inputs, startOnly)
+	if err != nil {
+		return "", err
+	}
+	return re.CallID, err
+}
 
-	p := inStartV2{
+// subStart is a start call wrapper returning the whole payload, for use by Start and Run
+func subStart(apiKey string, modelKey string, inputs []byte, startOnly bool) (outStartV3, error) {
+	p := inStartV3{
 		ID:          uuid.New().String(),
 		Created:     time.Now().Unix(),
 		APIKey:      apiKey,
 		ModelKey:    modelKey,
 		ModelInputs: inputs,
+		StartOnly:   startOnly,
 	}
 
-	re := outStartV2{}
+	re := outStartV3{}
 
-	url := endpoint + "start/v2/"
+	url := endpoint + "start/v3/"
 
-	err = post(url, &p, &re)
+	err := post(url, &p, &re)
 	if err != nil {
-		return "", err
+		return re, err
 	}
 
 	lower := strings.ToLower(re.Message)
 	if strings.Contains(lower, "error") {
-		return "", fmt.Errorf(re.Message)
+		return re, fmt.Errorf(re.Message)
 	}
 
-	return re.CallID, nil
+	return re, nil
 }
 
 // Check will check the status of an existing async inference task.
-func Check(apiKey string, callID string) (outCheckV2, error) {
-
-	p := inCheckV2{
+func Check(apiKey string, callID string) (Result, error) {
+	p := inCheckV3{
 		ID:       uuid.New().String(),
 		Created:  time.Now().Unix(),
 		APIKey:   apiKey,
@@ -74,18 +95,18 @@ func Check(apiKey string, callID string) (outCheckV2, error) {
 		LongPoll: true,
 	}
 
-	re := outCheckV2{}
+	re := Result{}
 
-	url := endpoint + "check/v2/"
+	url := endpoint + "check/v3/"
 
 	err := post(url, &p, &re)
 	if err != nil {
-		return outCheckV2{}, err
+		return Result{}, err
 	}
 
 	lower := strings.ToLower(re.Message)
 	if strings.Contains(lower, "error") {
-		return outCheckV2{}, fmt.Errorf(re.Message)
+		return Result{}, fmt.Errorf(re.Message)
 	}
 
 	return re, nil

--- a/types.go
+++ b/types.go
@@ -4,29 +4,29 @@ import "encoding/json"
 
 // This package defines the entirety of what data can be accepted on the inbound Post requests
 
-// InStartV2 Defines the acceptable payload into the task/start/v2 endpoint
-type inStartV2 struct {
+// InStartV3 Defines the acceptable payload into the task/start/v3 endpoint
+type inStartV3 struct {
 	ID          string          `json:"id" xml:"id" form:"id"`
 	Created     int64           `json:"created" xml:"created" form:"created"`
 	APIKey      string          `json:"apiKey" xml:"apiKey" form:"apiKey"`
 	ModelKey    string          `json:"modelKey" xml:"modelKey" form:"modelKey"`
+	StartOnly   bool            `json:"startOnly" xml:"startOnly" form:"startOnly"`
 	ModelInputs json.RawMessage `json:"modelInputs" xml:"modelInputs" form:"modelInputs"` // Keeps the dynamic substruct as raw bytes
-	Config      struct {
-		MachineID string `json:"machineID" xml:"machineID" form:"machineID"`
-	} `json:"config" xml:"config" form:"config"`
 }
 
-// OutStartV1 defines the payload to be returned by the task/start/v2 endpoint
-type outStartV2 struct {
-	ID         string `json:"id" xml:"id" form:"id"`
-	Message    string `json:"message" xml:"message" form:"message"`
-	Created    int64  `json:"created" xml:"created" form:"created"`
-	APIVersion string `json:"apiVersion" xml:"apiVersion" form:"apiVersion"`
-	CallID     string `json:"callID" xml:"callID" form:"callID"`
+// OutStartV3 defines the payload to be returned by the task/start/v3 endpoint
+type outStartV3 struct {
+	ID           string          `json:"id" xml:"id" form:"id"`
+	Message      string          `json:"message" xml:"message" form:"message"`
+	Created      int64           `json:"created" xml:"created" form:"created"`
+	APIVersion   string          `json:"apiVersion" xml:"apiVersion" form:"apiVersion"`
+	CallID       string          `json:"callID" xml:"callID" form:"callID"`
+	Finished     bool            `json:"finished" xml:"finished" form:"finished"`
+	ModelOutputs json.RawMessage `json:"modelOutputs" xml:"modelOutputs" form:"modelOutputs"`
 }
 
-// InCheckV1 Defines the acceptable payload into the task/check/v2 endpoint
-type inCheckV2 struct {
+// InCheckV3 Defines the acceptable payload into the task/check/v3 endpoint
+type inCheckV3 struct {
 	ID       string `json:"id" xml:"id" form:"id"`
 	Created  int64  `json:"created" xml:"created" form:"created"`
 	APIKey   string `json:"apiKey" xml:"apiKey" form:"apiKey"`
@@ -34,11 +34,14 @@ type inCheckV2 struct {
 	CallID   string `json:"callID" xml:"callID" form:"callID"`
 }
 
-// OutCheckV1 defines the payload to be returned by the task/check/v2 endpoint
-type outCheckV2 struct {
+// OutCheckV3 defines the payload to be returned by the task/check/v3 endpoint
+type outCheckV3 struct {
 	ID           string          `json:"id" xml:"id" form:"id"`
 	Message      string          `json:"message" xml:"message" form:"message"`
 	Created      int64           `json:"created" xml:"created" form:"created"`
 	APIVersion   string          `json:"apiVersion" xml:"apiVersion" form:"apiVersion"`
 	ModelOutputs json.RawMessage `json:"modelOutputs" xml:"modelOutputs" form:"modelOutputs"`
 }
+
+// Export Result, aliased from outCheckV3, which is the return of banana.Run and banana.Check
+type Result outCheckV3


### PR DESCRIPTION
# Why
latencies were slow, so we re-worked the backend (v3 handlers) to return results from the /start call by default, and only fall back on the check call if necessary.

Tested E2E