### PR TITLE
Add optional context parameter to model calls

### DIFF
--- a/banana.go
+++ b/banana.go
@@ -12,12 +12,12 @@ import (
 // Run will call the inference pipeline on custom models with the use of a model key.
 // It is a syncronous wrapper around the async Start and Check functions.
 func Run(apiKey string, modelKey string, inputs []byte) (Result, error) {
-	return RunContext(context.Background(), apiKey, modelKey, inputs)
+	return RunWithContext(context.Background(), apiKey, modelKey, inputs)
 }
 
-// RunContext is the same as Run, but with a non-default context.
+// RunWithContext is the same as Run, but with a non-default context.
 // This allows for in-progress cancellation.
-func RunContext(
+func RunWithContext(
 	ctx context.Context,
 	apiKey string,
 	modelKey string,
@@ -45,7 +45,7 @@ func RunContext(
 	// Else if long running, poll check until done
 	out := Result{}
 	for {
-		out, err = CheckContext(ctx, apiKey, res.CallID)
+		out, err = CheckWithContext(ctx, apiKey, res.CallID)
 		if err != nil {
 			return Result{}, err
 		}
@@ -60,12 +60,12 @@ func RunContext(
 
 // Start will start an async inference task and return a task ID.
 func Start(apiKey string, modelKey string, inputs []byte) (callID string, err error) {
-	return StartContext(context.Background(), apiKey, modelKey, inputs)
+	return StartWithContext(context.Background(), apiKey, modelKey, inputs)
 }
 
-// StartContext is the same as Start, but with a non-default context.
+// StartWithContext is the same as Start, but with a non-default context.
 // This allows for in-progress cancellation.
-func StartContext(
+func StartWithContext(
 	ctx context.Context,
 	apiKey string,
 	modelKey string,
@@ -115,12 +115,12 @@ func subStart(
 
 // Check will check the status of an existing async inference task.
 func Check(apiKey string, callID string) (Result, error) {
-	return CheckContext(context.Background(), apiKey, callID)
+	return CheckWithContext(context.Background(), apiKey, callID)
 }
 
-// CheckContext is the same as Check, but with a non-default context.
+// CheckWithContext is the same as Check, but with a non-default context.
 // This allows for in-progress cancellation.
-func CheckContext(ctx context.Context, apiKey string, callID string) (Result, error) {
+func CheckWithContext(ctx context.Context, apiKey string, callID string) (Result, error) {
 	p := inCheckV3{
 		ID:       uuid.New().String(),
 		Created:  time.Now().Unix(),

--- a/banana.go
+++ b/banana.go
@@ -1,6 +1,7 @@
 package banana
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -11,10 +12,20 @@ import (
 // Run will call the inference pipeline on custom models with the use of a model key.
 // It is a syncronous wrapper around the async Start and Check functions.
 func Run(apiKey string, modelKey string, inputs []byte) (Result, error) {
+	return RunContext(context.Background(), apiKey, modelKey, inputs)
+}
 
+// RunContext is the same as Run, but with a non-default context.
+// This allows for in-progress cancellation.
+func RunContext(
+	ctx context.Context,
+	apiKey string,
+	modelKey string,
+	inputs []byte,
+) (Result, error) {
 	// Start the task
 	startOnly := false
-	res, err := subStart(apiKey, modelKey, inputs, startOnly)
+	res, err := subStart(ctx, apiKey, modelKey, inputs, startOnly)
 	if err != nil {
 		return Result{}, err
 	}
@@ -34,7 +45,7 @@ func Run(apiKey string, modelKey string, inputs []byte) (Result, error) {
 	// Else if long running, poll check until done
 	out := Result{}
 	for {
-		out, err = Check(apiKey, res.CallID)
+		out, err = CheckContext(ctx, apiKey, res.CallID)
 		if err != nil {
 			return Result{}, err
 		}
@@ -49,8 +60,19 @@ func Run(apiKey string, modelKey string, inputs []byte) (Result, error) {
 
 // Start will start an async inference task and return a task ID.
 func Start(apiKey string, modelKey string, inputs []byte) (callID string, err error) {
+	return StartContext(context.Background(), apiKey, modelKey, inputs)
+}
+
+// StartContext is the same as Start, but with a non-default context.
+// This allows for in-progress cancellation.
+func StartContext(
+	ctx context.Context,
+	apiKey string,
+	modelKey string,
+	inputs []byte,
+) (callID string, err error) {
 	startOnly := true
-	re, err := subStart(apiKey, modelKey, inputs, startOnly)
+	re, err := subStart(ctx, apiKey, modelKey, inputs, startOnly)
 	if err != nil {
 		return "", err
 	}
@@ -58,7 +80,13 @@ func Start(apiKey string, modelKey string, inputs []byte) (callID string, err er
 }
 
 // subStart is a start call wrapper returning the whole payload, for use by Start and Run
-func subStart(apiKey string, modelKey string, inputs []byte, startOnly bool) (outStartV3, error) {
+func subStart(
+	ctx context.Context,
+	apiKey string,
+	modelKey string,
+	inputs []byte,
+	startOnly bool,
+) (outStartV3, error) {
 	p := inStartV3{
 		ID:          uuid.New().String(),
 		Created:     time.Now().Unix(),
@@ -72,7 +100,7 @@ func subStart(apiKey string, modelKey string, inputs []byte, startOnly bool) (ou
 
 	url := endpoint + "start/v3/"
 
-	err := post(url, &p, &re)
+	err := post(ctx, url, &p, &re)
 	if err != nil {
 		return re, err
 	}
@@ -87,6 +115,12 @@ func subStart(apiKey string, modelKey string, inputs []byte, startOnly bool) (ou
 
 // Check will check the status of an existing async inference task.
 func Check(apiKey string, callID string) (Result, error) {
+	return CheckContext(context.Background(), apiKey, callID)
+}
+
+// CheckContext is the same as Check, but with a non-default context.
+// This allows for in-progress cancellation.
+func CheckContext(ctx context.Context, apiKey string, callID string) (Result, error) {
 	p := inCheckV3{
 		ID:       uuid.New().String(),
 		Created:  time.Now().Unix(),
@@ -99,7 +133,7 @@ func Check(apiKey string, callID string) (Result, error) {
 
 	url := endpoint + "check/v3/"
 
-	err := post(url, &p, &re)
+	err := post(ctx, url, &p, &re)
 	if err != nil {
 		return Result{}, err
 	}

--- a/banana_test.go
+++ b/banana_test.go
@@ -56,7 +56,7 @@ func TestContext(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
 	defer cancel()
 
-	_, err = RunContext(ctx, testingAPIKey, testingModelKey, buf)
+	_, err = RunWithContext(ctx, testingAPIKey, testingModelKey, buf)
 
 	// Ensure that the context was cancelled.
 	if !errors.Is(err, context.DeadlineExceeded) {

--- a/banana_test.go
+++ b/banana_test.go
@@ -1,27 +1,33 @@
 package banana
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
+	"time"
+)
+
+const (
+	testingAPIKey         = "demo"
+	testingModelKey       = "carrot"
+	testingCarrotImageURL = "https://demo-images-banana.s3.us-west-1.amazonaws.com/image2.jpg"
 )
 
 func TestRunCarrot(t *testing.T) {
-
-	apiKey := "demo"
-	modelKey := "carrot"
 
 	type input struct {
 		ImageURL string `json:"imageURL"`
 	}
 
 	in := input{
-		ImageURL: "https://demo-images-banana.s3.us-west-1.amazonaws.com/image2.jpg",
+		ImageURL: testingCarrotImageURL,
 	}
 
 	bytesIn, _ := json.Marshal(in)
 
-	bananaOut, err := Run(apiKey, modelKey, bytesIn)
+	bananaOut, err := Run(testingAPIKey, testingModelKey, bytesIn)
 	if err != nil {
 		panic(err)
 	}
@@ -34,4 +40,26 @@ func TestRunCarrot(t *testing.T) {
 	json.Unmarshal(bananaOut.ModelOutputs, &out)
 	fmt.Println(out[0].Caption)
 
+}
+
+func TestContext(t *testing.T) {
+	buf, err := json.Marshal(map[string]string{
+		"imageURL": testingCarrotImageURL,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// We put a stupidly low timeout, to make sure we get a timeout error.
+	// The laws of physics *should* prohibit a value of 1ms from ever being
+	// a valid timeout... we'd hope at least.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+
+	_, err = RunContext(ctx, testingAPIKey, testingModelKey, buf)
+
+	// Ensure that the context was cancelled.
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("expected context.DeadlineExceeded error, got %v", err)
+	}
 }


### PR DESCRIPTION
Useful + good API design practice to allow user to passthrough
context into I/O operations like network calls. Specifically, we
want to possibly timeout requests to carrot and protect against
an indexing worker from getting blocked unnecessarily.

Was careful to ensure existing API remained intact, let me know
if there are any issues here though and will promptly fix them up.